### PR TITLE
Post v1.6.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,19 +4,19 @@ XMLStarlet CFFI
 
 
 .. image:: https://img.shields.io/pypi/v/xmlstarlet.svg
-        :target: https://pypi.python.org/pypi/xmlstarlet
+     :target: https://pypi.python.org/pypi/xmlstarlet
 
-.. image:: https://img.shields.io/travis/dimitern/xmlstarlet.svg
-        :target: https://travis-ci.org/dimitern/xmlstarlet
+.. image:: https://github.com/dimitern/xmlstarlet/workflows/Build%20and%20upload%20to%20PyPI/badge.svg?branch=master&event=push
+     :target: https://github.com/dimitern/xmlstarlet/actions?query=event%3Apush+branch%3Amaster+workflow%3A"Build+and+upload+to+PyPI"
+     :alt: cibuildwheel & PyPI
 
 .. image:: https://readthedocs.org/projects/xmlstarlet/badge/?version=latest
-        :target: https://xmlstarlet.readthedocs.io/en/latest/?badge=latest
-        :alt: Documentation Status
+     :target: https://xmlstarlet.readthedocs.io/en/latest/?badge=latest
+     :alt: Documentation Status
 
 .. image:: https://pyup.io/repos/github/dimitern/xmlstarlet/shield.svg
      :target: https://pyup.io/repos/github/dimitern/xmlstarlet/
      :alt: Updates
-
 
 
 XMLStarlet Toolkit: Python CFFI bindings
@@ -49,10 +49,16 @@ For some examples, have a look at `tests/test_xmlstarlet.py`.
 Credits
 -------
 
+Kudos to XMLStarlet and its maintainers and users (original sources on SourceForge_)!
+
 This package was created with Cookiecutter_ and the `audreyr/cookiecutter-pypackage`_ project template.
 
-Dependencies scanned by PyUp.io_
+Binary wheels built via GitHub Actions by cibuildwheel_
 
+Development `requirements.txt` dependencies scanned by PyUp.io_
+
+.. _SourceForge: https://sourceforge.net/projects/xmlstar/
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 .. _`audreyr/cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage
+.. _cibuildwheel: https://github.com/joerick/cibuildwheel
 .. _PyUp.io: https://pyup.io

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ author = u"Mikhail Grushinskiy"
 # the built documents.
 #
 # The short X.Y version.
-version = "1.6.5"
+version = "1.6.6"
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.5
+current_version = 1.6.6
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/dimitern/xmlstarlet",
-    version="1.6.5",
+    version="1.6.6",
     zip_safe=False,
 )

--- a/xmlstarlet/__init__.py
+++ b/xmlstarlet/__init__.py
@@ -30,7 +30,7 @@ _lib = xmlstarlet._xmlstarlet.lib  # pylint: disable=protected-access
 
 __author__ = """Mikhail Grushinskiy"""
 __email__ = "mgrouch@users.sourceforge.net"
-__version__ = "1.6.5"
+__version__ = "1.6.6"
 
 
 def _call_main(*args, main_func, escape_flag=-1):


### PR DESCRIPTION
Since Travis CI is no longer used for builds, update the README (and documentation) to include a build badge from GitHub Actions, and update the "Credits".