### PR TITLE
xmlErrorPtr to const xmlError * aligning with libxml 2.12

### DIFF
--- a/xmlstarlet/src/xml.c
+++ b/xmlstarlet/src/xml.c
@@ -104,7 +104,7 @@ void reportGenericError(void* ctx, const char * msg, ...) {
 /* by default all errors are reported */
 static ErrorInfo errorInfo = { NULL, NULL, VERBOSE, CONTINUE };
 
-void reportError(void *ptr, xmlErrorPtr error)
+void reportError(void *ptr, const xmlError *error)
 {
     ErrorInfo *errorInfo = (ErrorInfo*) ptr;
     assert(errorInfo);

--- a/xmlstarlet/src/xmlstar.h
+++ b/xmlstarlet/src/xmlstar.h
@@ -32,7 +32,7 @@ typedef struct _errorInfo {
     ErrorStop stop;
 } ErrorInfo;
 
-void reportError(void *ptr, xmlErrorPtr error);
+void reportError(void *ptr, const xmlError *error);
 void suppressErrors(void);
 
 typedef struct _gOptions {


### PR DESCRIPTION
ref:
- https://github.com/GNOME/libxml2/commit/45470611b047db78106dcb2fdbd4164163c15ab7
- https://github.com/GNOME/libxml2/commit/61034116d0a3c8b295c6137956adc3ae55720711